### PR TITLE
Correct Unit Test for #1

### DIFF
--- a/tests/Unit/InitialModelTest.php
+++ b/tests/Unit/InitialModelTest.php
@@ -10,11 +10,11 @@ class InitialModelTest extends TestCase
     use RefreshDatabase;
 
     /**
-     * Creates and Deletes User.
+     * Tests whether it is able to create a user.
      *
      * @return void
      */
-    public function test_create_and_delete_user()
+    public function test_create_user()
     {
         $user = \App\Models\User::create([
             'id' => \Illuminate\Support\Str::uuid(),
@@ -23,15 +23,14 @@ class InitialModelTest extends TestCase
         ]);
 
         $this->assertTrue(!is_null($user));
-
-        $user->delete();
-
-        $user2 = \App\Models\User::find($user->id);
-
-        $this->assertTrue(is_null($user2));
     }
 
-    public function test_create_and_delete_source()
+    /**
+     * Tests whether the User and Source Relationship works.
+     * 
+     * @return void
+     */
+    public function test_create_source()
     {
         $user = \App\Models\User::create([
             'id' => \Illuminate\Support\Str::uuid(),
@@ -49,14 +48,14 @@ class InitialModelTest extends TestCase
         $source_id = $user->sources[0]->id;
 
         $this->assertTrue($user->sources->count() == 1);
-
-        $user->sources()->delete();
-        $user->delete();
-
-        $this->assertFalse(!is_null(\App\Models\Source::find($source_id)));
     }
 
-    public function test_create_and_delete_takeaway()
+    /**
+     * Tests whether the Source and Takeaway Relationship works.
+     * 
+     * @return void
+     */
+    public function test_create_takeaway()
     {
         $user = \App\Models\User::create([
             'id' => \Illuminate\Support\Str::uuid(),
@@ -77,17 +76,14 @@ class InitialModelTest extends TestCase
         ]);
 
         $this->assertTrue($user->sources[0]->takeaways->count() == 1);
-
-        $takeaway_id = $user->sources[0]->takeaways[0]->id;
-
-        $user->sources[0]->takeaways()->delete();
-        $user->sources()->delete();
-        $user->delete();
-
-        $this->assertFalse(!is_null(\App\Models\Source::find($takeaway_id)));
     }
 
-    public function test_create_and_delete_tags()
+    /**
+     * Tests whether the Source and Tag relationship works.
+     * 
+     * @return void
+     */
+    public function test_create_tags()
     {
         $user = \App\Models\User::create([
             'id' => \Illuminate\Support\Str::uuid(),
@@ -104,36 +100,9 @@ class InitialModelTest extends TestCase
 
         $this->assertTrue(!is_null($user->sources[0]->id));
 
-        /**
-         * At this point, source_id has to be explicitly mentioned and I wonder why.
-         */
-        $user->sources[0]->tags()->create([
-            'name' => 'test_a',
-        ]);
+        $user->sources[0]->tags()->create(['name' => 'test_a']);
+        $user->sources[0]->tags()->create(['name' => 'test_b']);
 
-        $user->sources[0]->tags()->create([
-            'name' => 'test_b',
-        ]);
-
-        // \App\Models\Tag::create([
-        //     'source_id' => $user->sources[0]->id,
-        //     'name' => 'test_a',
-        // ]);
-
-        // \App\Models\Tag::create([
-        //     'source_id' => $user->sources[0]->id,
-        //     'name' => 'test_b',
-        // ]);
-
-        $source = \App\Models\Source::find($user->sources[0]->id);
-        $tags = $source->tags();
-
-        $this->assertTrue($tags->count() == 2);
-
-        $tags->delete();
-        $this->assertFalse($tags->count() == 2);
-
-        $source->delete();
-        $user->delete();
+        $this->assertTrue(\App\Models\Source::find($user->sources[0]->id)->tags()->count() == 2);
     }
 }


### PR DESCRIPTION
The initial implementation I made was invalid as unit tests are supposed to have a separate working environment to avoid accidental losses in production.

This commit will remove the code that deletes all created models as the `RefreshDatabase` trait can do the trick.